### PR TITLE
Fix three pre-existing test regressions on the 2.x line

### DIFF
--- a/formkit_ninja/models.py
+++ b/formkit_ninja/models.py
@@ -312,6 +312,25 @@ class NodeQS(models.QuerySet):
                 warnings.warn(f"{E}")
 
 
+def _coerce_node_numeric(attr: str, val):
+    """Coerce a promoted CharField value (min/max/step) to the numeric form the
+    node JSON should carry, matching get_node_values(). min/max -> int when
+    integer-valued; step -> int when integer-valued, else the original string.
+    Non-numeric attrs and unparseable values are returned unchanged."""
+    if attr in ("min", "max"):
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return val
+    if attr == "step":
+        try:
+            f = float(val)
+            return int(f) if f.is_integer() else val
+        except (TypeError, ValueError):
+            return val
+    return val
+
+
 @pghistory.track()
 @pgtrigger.register(
     pgtrigger.Protect(
@@ -515,7 +534,7 @@ class FormKitSchemaNode(UuidIdModel):
                     elif key in self.node:
                         self.node.pop(key, None)
                 elif val not in (None, ""):
-                    self.node[key] = val
+                    self.node[key] = _coerce_node_numeric(attr, val)
                 elif already_in_node:
                     self.node.pop(key, None)
 

--- a/tests/parser/test_partisipanodepath_rewritten.py
+++ b/tests/parser/test_partisipanodepath_rewritten.py
@@ -91,7 +91,8 @@ class TestPartisipaNodePathRewritten:
         # Debug: Print generated models for inspection
         models_dir = output_dir / "models"
         if models_dir.exists():
-            model_files = list(models_dir.glob("*.py"))
+            # Exclude the package __init__.py; glob order is filesystem-dependent.
+            model_files = [f for f in models_dir.glob("*.py") if f.name != "__init__.py"]
             if model_files:
                 models_content_debug = model_files[0].read_text()
                 # Check for syntax errors manually
@@ -106,16 +107,16 @@ class TestPartisipaNodePathRewritten:
                         print(f"{marker}{i:3}: {line}")
                     raise
 
-        # Verify generated models.py has Partisipa customizations (only if files exist)
+        # Verify generated models.py has Partisipa customizations (only if files exist).
+        # Read all generated model files (excluding the package __init__.py) and
+        # concatenate, so the assertions don't depend on filesystem glob order.
         models_dir = output_dir / "models"
-        model_files = list(models_dir.glob("*.py")) if models_dir.exists() else []
+        model_files = [f for f in models_dir.glob("*.py") if f.name != "__init__.py"] if models_dir.exists() else []
 
-        if len(model_files) > 0:
-            models_file = model_files[0]  # Get the first model file
-        else:
+        if not model_files:
             # Skip test if no files generated
             pytest.skip("No model files generated")
-        models_content = models_file.read_text()
+        models_content = "\n".join(f.read_text() for f in model_files)
 
         # Verify submission field for root model (depth=1)
         assert "submission = models.OneToOneField" in models_content

--- a/tests/test_admin_best_practice.py
+++ b/tests/test_admin_best_practice.py
@@ -118,8 +118,8 @@ def test_repeater_node_fields(admin_page: Page):
     # Save and continue to load repeater fields
     admin_page.get_by_role("button", name="Save and continue editing").click()
 
-    # Use ID selector for addLabel
-    admin_page.locator("#id_addLabel").fill("Add row")
+    # Use ID selector for add_label (model field -> Django id `id_add_label`)
+    admin_page.locator("#id_add_label").fill("Add row")
     admin_page.get_by_role("button", name="Save", exact=True).click()
 
     node = models.FormKitSchemaNode.objects.get(label="Test Repeater")

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ wheels = [
 
 [[package]]
 name = "formkit-ninja"
-version = "2.2"
+version = "2.3"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Fixes the 3 pytest failures currently red on `main` (2.3) — unrelated to any feature work, surfaced while prepping the 2.4 release.

## Fixes

1. **`test_issue_22::test_issue_22_enhanced_fields`** — real bug. The "sync promoted columns to node" logic in `FormKitSchemaNode.save()` wrote the `min`/`max`/`step` **CharField strings** (e.g. `"1"`) straight into the `node` JSON, while `get_node_values()` emits the int `1`. Stored JSON and reconstructed JSON disagreed. Added `_coerce_node_numeric()` (mirrors `get_node_values`) and applied it in the sync block, so `node["min"]` is `1` again.

2. **`test_partisipanodepath_rewritten::...partisipa_customizations`** — flaky test. `models_dir.glob("*.py")[0]` picked an arbitrary file; on CI's filesystem ordering it returned the package `__init__.py` instead of the model module, so the customization assertions failed. Now excludes `__init__.py` and concatenates all generated model files (order-independent).

3. **`test_admin_best_practice::test_repeater_node_fields[chromium]`** — stale selector. The repeater `addLabel` is the model field `add_label`, rendered by Django as `#id_add_label`; the test still filled `#id_addLabel` and timed out. Updated the selector.

Also syncs `uv.lock` to `2.3` (it was stale at `2.2`).

## Verification

Full suite run locally (Postgres + chromium): the 3 target tests pass; **780 passed**. (6 `test_parser/test_formatter` failures locally are ruff-version skew — my local ruff `0.14.13` vs the pinned version — and pass in CI.)

Merging this unblocks the red CI on #37 (code_scheme / 2.4) once it rebases on `main`.