### PR TITLE
Add automated PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release
+
+# Automatic PyPI release on a version tag.
+#
+# To cut a release:
+#   1. Bump `version` in pyproject.toml on main, commit, merge.
+#   2. Tag the merged commit with the SAME version (no "v" prefix), e.g.:
+#        git tag 2.5 && git push origin 2.5
+#   3. This workflow verifies the tag, builds, publishes to PyPI, and creates
+#      a GitHub Release with auto-generated notes.
+#
+# Publishing uses PyPI Trusted Publishing (OIDC) — no API token secret.
+# ONE-TIME SETUP (maintainer, on PyPI):
+#   pypi.org -> project formkit-ninja -> Settings -> Publishing ->
+#   "Add a new trusted publisher" (GitHub Actions):
+#     Owner:        catalpainternational
+#     Repository:   formkit-ninja
+#     Workflow:     release.yml
+#     Environment:  pypi
+#   (For the very first publish on a brand-new project name, add it as a
+#    "pending publisher" instead.)
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Tag must equal pyproject version
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          ver="$(grep -m1 '^version' pyproject.toml | sed -E 's/^version *= *"([^"]+)".*/\1/')"
+          echo "tag=$tag  pyproject=$ver"
+          if [ "$tag" != "$ver" ]; then
+            echo "::error::Tag '$tag' does not match pyproject version '$ver'. Bump pyproject.toml to match the tag."
+            exit 1
+          fi
+      - name: Tagged commit must be on main
+        run: |
+          git fetch --no-tags --depth=100 origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tagged commit $GITHUB_SHA is not on main. Release only from merged, CI-green main."
+            exit 1
+          fi
+
+  build:
+    name: Build distributions
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Check metadata
+        run: uv run --with twine twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/formkit-ninja/
+    permissions:
+      id-token: write # OIDC for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,47 @@
+# Releasing
+
+Releases are automated by [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+Pushing a version tag builds the package, publishes it to PyPI, and creates a
+GitHub Release.
+
+## Cut a release
+
+1. Bump `version` in `pyproject.toml` on a branch and merge it to `main`
+   (update `CHANGELOG.md` in the same PR).
+2. Tag the merged commit with the **same** version — no `v` prefix, matching the
+   existing tag style (`2.3`, `2.4`, …):
+
+   ```bash
+   git checkout main && git pull
+   git tag 2.5
+   git push origin 2.5
+   ```
+
+3. The workflow then:
+   - **verifies** the tag equals `pyproject.toml`'s `version` and that the commit
+     is on `main` (so you can't accidentally release un-merged or mismatched code);
+   - **builds** the sdist + wheel (`uv build`) and `twine check`s them;
+   - **publishes** to PyPI via Trusted Publishing;
+   - **creates** a GitHub Release with auto-generated notes.
+
+If the tag and `pyproject` version disagree, the run fails fast — bump and re-tag.
+
+## One-time setup (maintainer)
+
+Publishing uses **PyPI Trusted Publishing (OIDC)** — there is no API token secret
+to manage. On [pypi.org](https://pypi.org), open the `formkit-ninja` project →
+**Settings → Publishing → Add a new trusted publisher** (GitHub Actions):
+
+| Field        | Value                          |
+|--------------|--------------------------------|
+| Owner        | `catalpainternational`         |
+| Repository   | `formkit-ninja`                |
+| Workflow     | `release.yml`                  |
+| Environment  | `pypi`                         |
+
+The `pypi` GitHub environment already exists; add reviewers/protection to it if
+you want a manual approval gate before each publish.
+
+> Prefer an API token instead? Replace the `publish` job's OIDC step with
+> `pypa/gh-action-pypi-publish@release/v1` configured with
+> `password: ${{ secrets.PYPI_API_TOKEN }}` and add that repo secret.


### PR DESCRIPTION
Automates releases so version/tag/PyPI never drift again.

## How it works

Push a version tag (matching the existing style — `2.5`, no `v` prefix) and `.github/workflows/release.yml`:

1. **verify** — fails fast unless the tag equals `pyproject.toml`'s `version` **and** the tagged commit is on `main`. (Directly addresses the current drift: 2.3/2.4 shipped to PyPI without matching git tags.)
2. **build** — `uv build` (sdist + wheel) + `twine check`.
3. **publish** — PyPI **Trusted Publishing (OIDC)** via the `pypi` environment. No API token secret to manage.
4. **github-release** — creates a GitHub Release with auto-generated notes + the artifacts.

## Release flow (documented in `docs/releasing.md`)

```bash
# bump version in pyproject.toml + CHANGELOG on a PR, merge to main, then:
git tag 2.5 && git push origin 2.5
```

## One-time setup required before first use

On PyPI: `formkit-ninja` → Settings → Publishing → add a trusted publisher —
owner `catalpainternational`, repo `formkit-ninja`, workflow `release.yml`, environment `pypi`.
The `pypi` GitHub environment is already created (add approval reviewers to it if you want a manual gate).

Token-based publishing is documented as a fallback if you'd rather not use OIDC.

## Note

This does not retro-tag the already-published 2.3 / un-published 2.4 — see follow-up. After merge, `2.5` onward is fully automated.