### PR TITLE
fix(models): stop additional_props overriding recognised node fields

### DIFF
--- a/formkit_ninja/api.py
+++ b/formkit_ninja/api.py
@@ -16,8 +16,8 @@ from ninja import Field, ModelSchema, Router, Schema
 from pydantic import BaseModel, validator
 
 from formkit_ninja import formkit_schema, models
-from formkit_ninja.schema_props import merge_additional_props_under, strip_stale_recognised_props
 from formkit_ninja.notifications import get_default_notifier
+from formkit_ninja.schema_props import merge_additional_props_under, strip_stale_recognised_props
 
 notifier = get_default_notifier()
 

--- a/formkit_ninja/api.py
+++ b/formkit_ninja/api.py
@@ -16,6 +16,7 @@ from ninja import Field, ModelSchema, Router, Schema
 from pydantic import BaseModel, validator
 
 from formkit_ninja import formkit_schema, models
+from formkit_ninja.schema_props import merge_additional_props_under, strip_stale_recognised_props
 from formkit_ninja.notifications import get_default_notifier
 
 notifier = get_default_notifier()
@@ -462,11 +463,12 @@ def create_or_update_child_node(payload: FormKitNodeIn, raw_payload_dict: dict |
         values["name"] = payload.preferred_name
     child.node.update(values)
     if payload.additional_props is not None:
-        child.node.update(payload.additional_props)
-        # Also store additional_props in the model field
+        filtered_props = strip_stale_recognised_props(payload.additional_props, values)
+        merge_additional_props_under(child.node, filtered_props)
         if child.additional_props is None:
             child.additional_props = {}
-        child.additional_props.update(payload.additional_props)
+        child.additional_props.update(filtered_props)
+        child.additional_props = strip_stale_recognised_props(child.additional_props, values)
 
     # Extract and preserve unrecognized fields from raw payload
     if raw_payload_dict is not None:

--- a/formkit_ninja/migrations/0045_strip_stale_additional_props.py
+++ b/formkit_ninja/migrations/0045_strip_stale_additional_props.py
@@ -1,0 +1,65 @@
+# Remove stale recognised FormKit props duplicated in additional_props when node
+# JSON already carries the authoritative value (issue #41).
+import pgtrigger
+from django.db import migrations
+
+
+def _authoritative_node_dict(node) -> dict:
+    """Node JSON plus promoted column values that would be served from the model."""
+    auth = dict(node.node) if isinstance(node.node, dict) else {}
+    promoted = (
+        ("icon", "icon"),
+        ("title", "title"),
+        ("code_scheme", "code_scheme"),
+        ("readonly", "readonly"),
+        ("sections_schema", "sectionsSchema"),
+        ("min", "min"),
+        ("max", "max"),
+        ("step", "step"),
+        ("add_label", "addLabel"),
+        ("up_control", "upControl"),
+        ("down_control", "downControl"),
+        ("django_field_type", "django_field_type"),
+        ("django_field_args", "django_field_args"),
+        ("django_field_positional_args", "django_field_positional_args"),
+        ("pydantic_field_type", "pydantic_field_type"),
+        ("extra_imports", "extra_imports"),
+        ("validators", "validators"),
+        ("list_filter", "list_filter"),
+    )
+    for attr, key in promoted:
+        val = getattr(node, attr, None)
+        if val in (None, "", [], {}):
+            continue
+        if isinstance(val, bool) and attr in ("readonly", "list_filter") and not val:
+            continue
+        if isinstance(val, bool) and attr in ("up_control", "down_control") and val:
+            continue
+        auth[key] = val
+    return auth
+
+
+def forward(apps, schema_editor):
+    FormKitSchemaNode = apps.get_model("formkit_ninja", "FormKitSchemaNode")
+    from formkit_ninja.schema_props import strip_stale_recognised_props
+
+    with pgtrigger.ignore("formkit_ninja.FormKitSchemaNode:protect_node_updates"):
+        for node in FormKitSchemaNode.objects.filter(additional_props__isnull=False).iterator():
+            props = node.additional_props
+            if not isinstance(props, dict):
+                continue
+            authoritative = _authoritative_node_dict(node)
+            cleaned = strip_stale_recognised_props(props, authoritative)
+            if cleaned != props:
+                node.additional_props = cleaned or None
+                node.save(update_fields=["additional_props"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("formkit_ninja", "0044_backfill_code_scheme_pnds"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, migrations.RunPython.noop),
+    ]

--- a/formkit_ninja/models.py
+++ b/formkit_ninja/models.py
@@ -20,6 +20,7 @@ from django.utils import timezone
 from rich.console import Console
 
 from formkit_ninja import formkit_schema, triggers
+from formkit_ninja.schema_props import merge_additional_props_under, strip_stale_recognised_props
 
 # Re export "form_submission" models
 from formkit_ninja.code_generation_config import CodeGenerationConfig  # noqa: F401
@@ -562,6 +563,9 @@ class FormKitSchemaNode(UuidIdModel):
                 elif already_in_node:
                     self.node.pop(key, None)
 
+        if isinstance(self.additional_props, dict) and isinstance(self.node, dict):
+            self.additional_props = strip_stale_recognised_props(self.additional_props, self.node)
+
         # Resolve code generation defaults if not set
         self.resolve_code_generation_defaults()
 
@@ -710,16 +714,10 @@ class FormKitSchemaNode(UuidIdModel):
         if self.list_filter:
             values["list_filter"] = self.list_filter
 
-        # Merge additional_props into the top level and ensure it's removed as a separate key
+        # Merge additional_props under recognised node keys (do not override node/columns)
         values.pop("additional_props", None)
         if self.additional_props and len(self.additional_props) > 0:
-            # Handle nested additional_props structure
-            props_to_merge = self.additional_props
-            if "additional_props" in props_to_merge:
-                props_to_merge = props_to_merge["additional_props"]
-            # Filter out None values to prevent Pydantic validation errors
-            clean_props = {k: v for k, v in props_to_merge.items() if v is not None}
-            values.update(clean_props)
+            values = merge_additional_props_under(values, self.additional_props)
 
         if self.node_type == "$el" and not values.get("$el"):
             values["$el"] = "span"

--- a/formkit_ninja/models.py
+++ b/formkit_ninja/models.py
@@ -20,7 +20,6 @@ from django.utils import timezone
 from rich.console import Console
 
 from formkit_ninja import formkit_schema, triggers
-from formkit_ninja.schema_props import merge_additional_props_under, strip_stale_recognised_props
 
 # Re export "form_submission" models
 from formkit_ninja.code_generation_config import CodeGenerationConfig  # noqa: F401
@@ -30,6 +29,7 @@ from formkit_ninja.form_submission.models import (
     SubmissionField,  # noqa: F401
     SubmissionFile,  # noqa: F401
 )
+from formkit_ninja.schema_props import merge_additional_props_under, strip_stale_recognised_props
 from formkit_ninja.utils import short_uuid
 
 console = Console()

--- a/formkit_ninja/schema_props.py
+++ b/formkit_ninja/schema_props.py
@@ -1,0 +1,141 @@
+"""
+Helpers for reconciling recognised FormKit node props vs additional_props storage.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from formkit_ninja import formkit_schema
+
+# Keys handled structurally when parsing nodes (see FormKitNode.parse_obj).
+STRUCTURAL_NODE_KEYS = frozenset(
+    {
+        "$formkit",
+        "$el",
+        "$cmp",
+        "if",
+        "for",
+        "then",
+        "else",
+        "children",
+        "node_type",
+        "formkit",
+        "id",
+    }
+)
+
+# Promoted model columns written into node JSON by FormKitSchemaNode.save / get_node_values.
+PROMOTED_NODE_KEYS = frozenset(
+    {
+        "icon",
+        "title",
+        "code_scheme",
+        "readonly",
+        "sectionsSchema",
+        "min",
+        "max",
+        "step",
+        "addLabel",
+        "upControl",
+        "downControl",
+        "django_field_type",
+        "django_field_args",
+        "django_field_positional_args",
+        "pydantic_field_type",
+        "extra_imports",
+        "validators",
+        "list_filter",
+    }
+)
+
+_RECOGNISED_KEYS_CACHE: frozenset[str] | None = None
+
+
+def _collect_pydantic_field_keys(model_class: type) -> set[str]:
+    keys: set[str] = set()
+    for name, field in model_class.__fields__.items():
+        keys.add(name)
+        if field.alias:
+            keys.add(field.alias)
+    return keys
+
+
+def _all_schema_props_classes() -> set[type]:
+    classes: set[type] = {formkit_schema.FormKitSchemaProps}
+    pending = [formkit_schema.FormKitSchemaProps]
+    while pending:
+        cls = pending.pop()
+        for sub in cls.__subclasses__():
+            if sub not in classes:
+                classes.add(sub)
+                pending.append(sub)
+    return classes
+
+
+def recognised_node_prop_keys() -> frozenset[str]:
+    """
+    Return FormKit node property names that have first-class schema / API representation.
+    """
+    global _RECOGNISED_KEYS_CACHE
+    if _RECOGNISED_KEYS_CACHE is not None:
+        return _RECOGNISED_KEYS_CACHE
+
+    keys: set[str] = set(STRUCTURAL_NODE_KEYS) | set(PROMOTED_NODE_KEYS)
+    keys.add("additional_props")
+
+    for cls in _all_schema_props_classes():
+        keys.update(_collect_pydantic_field_keys(cls))
+
+    # API payload fields (lazy import avoids circular dependency with api.py).
+    from formkit_ninja.api import FormKitNodeIn
+
+    keys.update(_collect_pydantic_field_keys(FormKitNodeIn))
+    keys.discard("parent_id")
+    keys.discard("uuid")
+
+    _RECOGNISED_KEYS_CACHE = frozenset(keys)
+    return _RECOGNISED_KEYS_CACHE
+
+
+def _flatten_additional_props(props: dict[str, Any]) -> dict[str, Any]:
+    """Unwrap nested additional_props bucket if present."""
+    if "additional_props" in props and isinstance(props.get("additional_props"), dict):
+        nested = props["additional_props"]
+        return {k: v for k, v in props.items() if k != "additional_props"} | nested
+    return props
+
+
+def merge_additional_props_under(values: dict[str, Any], props: dict[str, Any] | None) -> dict[str, Any]:
+    """
+    Merge additional_props into values without overriding keys already present.
+    """
+    if not props:
+        return values
+    flat_props = _flatten_additional_props(props)
+    clean_props = {k: v for k, v in flat_props.items() if v is not None}
+    for key, val in clean_props.items():
+        if key not in values:
+            values[key] = val
+    return values
+
+
+def strip_stale_recognised_props(
+    props: dict[str, Any] | None,
+    authoritative: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """
+    Remove recognised keys from props when the same key exists in authoritative data.
+    """
+    if not props:
+        return {}
+    flat_props = _flatten_additional_props(props)
+    if not authoritative:
+        return dict(flat_props)
+
+    recognised = recognised_node_prop_keys()
+    return {
+        key: val
+        for key, val in flat_props.items()
+        if key not in recognised or key not in authoritative
+    }

--- a/formkit_ninja/schema_props.py
+++ b/formkit_ninja/schema_props.py
@@ -4,7 +4,9 @@ Helpers for reconciling recognised FormKit node props vs additional_props storag
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Type
+
+from pydantic import BaseModel
 
 from formkit_ninja import formkit_schema
 
@@ -52,7 +54,7 @@ PROMOTED_NODE_KEYS = frozenset(
 _RECOGNISED_KEYS_CACHE: frozenset[str] | None = None
 
 
-def _collect_pydantic_field_keys(model_class: type) -> set[str]:
+def _collect_pydantic_field_keys(model_class: Type[BaseModel]) -> set[str]:
     keys: set[str] = set()
     for name, field in model_class.__fields__.items():
         keys.add(name)
@@ -61,8 +63,8 @@ def _collect_pydantic_field_keys(model_class: type) -> set[str]:
     return keys
 
 
-def _all_schema_props_classes() -> set[type]:
-    classes: set[type] = {formkit_schema.FormKitSchemaProps}
+def _all_schema_props_classes() -> set[Type[BaseModel]]:
+    classes: set[Type[BaseModel]] = {formkit_schema.FormKitSchemaProps}
     pending = [formkit_schema.FormKitSchemaProps]
     while pending:
         cls = pending.pop()
@@ -134,8 +136,4 @@ def strip_stale_recognised_props(
         return dict(flat_props)
 
     recognised = recognised_node_prop_keys()
-    return {
-        key: val
-        for key, val in flat_props.items()
-        if key not in recognised or key not in authoritative
-    }
+    return {key: val for key, val in flat_props.items() if key not in recognised or key not in authoritative}

--- a/tests/test_data_loss_roundtrip.py
+++ b/tests/test_data_loss_roundtrip.py
@@ -488,7 +488,9 @@ def test_api_preserves_additional_props_in_database(admin_client):
     assert retrieved_node.additional_props is not None, "additional_props should be stored in database"
     assert "onClick" in retrieved_node.additional_props, "onClick should be preserved in additional_props in database"
     assert retrieved_node.additional_props["onClick"] == "$attrs.removeAction", f"onClick value should match. Expected: $attrs.removeAction, Got: {retrieved_node.additional_props.get('onClick')}"
-    assert "format" in retrieved_node.additional_props, "format should be preserved in additional_props in database"
+    # Recognised schema props (e.g. format) are promoted to node, not duplicated in additional_props
+    assert retrieved_node.node.get("format") == "DD/MM/YYYY"
+    assert "format" not in retrieved_node.additional_props
     assert "customField" in retrieved_node.additional_props, "customField should be preserved in additional_props in database"
 
 

--- a/tests/test_issue_41.py
+++ b/tests/test_issue_41.py
@@ -1,0 +1,84 @@
+"""Regression tests for issue #41: asymmetric additional_props reconciliation."""
+
+import pytest
+
+from formkit_ninja import api, models
+from tests.factories import FormKitSchemaFactory, GroupNodeFactory
+
+
+@pytest.mark.django_db
+def test_serve_node_validation_wins_over_stale_additional_props():
+    """Reproduce issue #41: node validation must not be overridden by stale column copy."""
+    node = models.FormKitSchemaNode.objects.create(
+        label="x",
+        node={
+            "id": "f",
+            "name": "f",
+            "$formkit": "number",
+            "validation": "required|min:1",
+        },
+        additional_props={"validation": "required"},
+    )
+
+    served = api.node_queryset_response(models.FormKitSchemaNode.objects.filter(pk=node.pk))[0]
+    node_dict = served.dict(by_alias=True, exclude_none=True)["node"]
+    assert node_dict["validation"] == "required|min:1"
+
+    values = node.get_node_values()
+    assert values["validation"] == "required|min:1"
+
+
+@pytest.mark.django_db
+def test_api_save_validation_not_clobbered_by_additional_props():
+    """API save: top-level validation must win over additional_props.validation."""
+    schema = FormKitSchemaFactory(label="Issue 41 API")
+    group = GroupNodeFactory(label="Group", node={"$formkit": "group", "name": "g"})
+    models.FormComponents.objects.create(schema=schema, node=group)
+
+    payload = api.FormKitNodeIn(
+        formkit="number",
+        label="Field",
+        name="amount",
+        parent_id=group.id,
+        validation="required|min:1",
+        additional_props={"validation": "required"},
+    )
+    child, errors = api.create_or_update_child_node(payload)
+    assert not errors
+    child.refresh_from_db()
+    assert child.node["validation"] == "required|min:1"
+
+
+@pytest.mark.django_db
+def test_additional_props_legacy_only_key_still_served():
+    """Legacy Partisipa layout: validation-messages only in column is still served."""
+    node = models.FormKitSchemaNode.objects.create(
+        label="x",
+        node={"id": "f", "name": "f", "$formkit": "text", "validation": "required"},
+        additional_props={"validation-messages": {"required": "This field is required"}},
+    )
+
+    values = node.get_node_values()
+    assert values["validation"] == "required"
+    assert values["validation-messages"] == {"required": "This field is required"}
+
+
+@pytest.mark.django_db
+def test_save_strips_stale_validation_from_additional_props_column():
+    """Model save removes stale recognised duplicates from additional_props."""
+    node = models.FormKitSchemaNode.objects.create(
+        label="x",
+        node_type="$formkit",
+        node={
+            "id": "f",
+            "name": "f",
+            "$formkit": "number",
+            "validation": "required|min:1",
+        },
+        additional_props={"validation": "required", "class": "my-field"},
+    )
+
+    node.save()
+    node.refresh_from_db()
+    assert "validation" not in (node.additional_props or {})
+    assert node.additional_props == {"class": "my-field"}


### PR DESCRIPTION
## Summary
- Make serve and save symmetric for recognised FormKit node props: `node` (and promoted model columns) are authoritative; `additional_props` only fills gaps.
- Add `formkit_ninja/schema_props.py` with shared merge/strip helpers used by `get_node_values`, API save, and model `save()`.
- Add migration `0045` to remove stale recognised-key duplicates from existing `additional_props` rows.

Fixes #41

## Test plan
- [x] `uv run pytest tests/test_issue_41.py` — issue shell repro, API save, legacy `validation-messages`, column sanitisation
- [x] `uv run pytest tests/test_partisipa_yaml.py` — legacy Partisipa layout preserved
- [x] `uv run pytest tests/test_data_loss_roundtrip.py` — roundtrip behaviour updated for recognised props promoted to `node`
- [x] Full non-playwright suite: 769 passed, 80.20% coverage


Made with [Cursor](https://cursor.com)