### PR TITLE
fix: reconcile orphaned SeparatedSubmission rows on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Orphaned `SeparatedSubmission` rows are now reconciled away** — `from_submission`
+  upserts one derived row per repeater-row `uuid` but previously never deleted rows
+  whose `uuid` had disappeared from canonical `Submission.fields` (web-form round-trips
+  that drop/regenerate `uuid`, flat↔repeater migrations, string→Decimal retypes, imports
+  bypassing `save`). Those phantom rows are invisible in canonical fields but ARE served
+  by the derived-model endpoints, so they double-counted in cumulative aggregates
+  (e.g. partisipa-import's FF 11 infrastructure carryforward). `from_submission` now
+  deletes, on every save, any `SeparatedSubmission` for the submission that is not part
+  of the rows it just wrote (root + every repeater row at every nesting depth) — stateless
+  and self-healing. **Behavioral change:** a derived row absent from canonical fields is
+  removed and its CASCADE-linked children and dependent `SeparatedSubmissionImport` /
+  `Flag` rows go with it.
+
+### Added
+
+- **`reconcile_separated_submissions` management command** — idempotent one-time sweep that
+  deletes pre-existing orphaned `SeparatedSubmission` rows across all submissions (supports
+  `--dry-run`). Run on deploy and on every fresh staging/prod restore to clean historical
+  orphans the on-save reconcile cannot reach retroactively.
+- **`all_repeater_uuids` helper** (`form_submission/utils.py`) — recursively collects every
+  repeater-row `uuid` at all nesting depths, complementing the one-level `get_repeaters_uuids`.
+
 ## [2.4] - 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`reconcile_separated_submissions` management command** — idempotent one-time sweep that
-  deletes pre-existing orphaned `SeparatedSubmission` rows across all submissions (supports
-  `--dry-run`). Run on deploy and on every fresh staging/prod restore to clean historical
-  orphans the on-save reconcile cannot reach retroactively.
+  deletes pre-existing orphaned `SeparatedSubmission` rows across all submissions. Run on
+  deploy and on every fresh staging/prod restore to clean historical orphans the on-save
+  reconcile cannot reach retroactively. Safety: `--dry-run` previews; a per-submission guard
+  skips (and reports) any submission whose canonical fields declare no repeaters yet still
+  has derived rows — the blanked/odd-shaped-`fields` case that would otherwise mass-delete —
+  unless `--force` is given; unparseable documents are skipped without aborting the sweep;
+  and a valid row pointing its `repeater_parent` at an orphan is detached before the delete
+  so a stale FK can't cascade away live data.
 - **`all_repeater_uuids` helper** (`form_submission/utils.py`) — recursively collects every
   repeater-row `uuid` at all nesting depths, complementing the one-level `get_repeaters_uuids`.
 

--- a/formkit_ninja/form_submission/models.py
+++ b/formkit_ninja/form_submission/models.py
@@ -128,6 +128,9 @@ class _SeparatedSubmissionManagerBase(models.Manager):
 
         results: list[tuple[SeparatedSubmission, bool]] = []
 
+        # Track every row we (re)write so we can reconcile away orphans below.
+        written_pks: set = {main.pk}
+
         # Process repeaters. 'fields[:-1]' are the children.
         # We reverse to process top-level children before deeper children (Top-Down)
         repeater_data = reversed(fields[:-1])
@@ -136,8 +139,25 @@ class _SeparatedSubmissionManagerBase(models.Manager):
             res = self._save_repeater_chunk(main, item_data)  # type: ignore[arg-type]
             if res:
                 results.append(res)
+                written_pks.add(res[0].pk)
 
         results.append((main, main_created))  # type: ignore[arg-type]
+
+        # Reconcile away orphaned derived rows (#2252).
+        #
+        # ``from_submission`` upserts one SeparatedSubmission per repeater-row
+        # uuid. When a row's uuid changes or disappears from canonical
+        # ``Submission.fields`` (web-form round-trip dropping/regenerating uuid,
+        # flat<->repeater migrations, string->Decimal retypes, imports bypassing
+        # save), the old derived row was historically left behind forever. Those
+        # phantom rows are invisible in canonical fields but ARE served by the
+        # derived-model endpoints, so they double-count in cumulative aggregates.
+        #
+        # The valid set is exactly the rows we just wrote (root + every repeater
+        # row at every nesting depth, since ``flatten`` recurses). Deleting the
+        # rest is stateless and self-healing — a no-op once consistent — and
+        # cascades to child rows and their dependent Import/Flag rows.
+        self.filter(submission=sub).exclude(pk__in=written_pks).delete()
 
         return results
 

--- a/formkit_ninja/form_submission/utils.py
+++ b/formkit_ninja/form_submission/utils.py
@@ -178,6 +178,30 @@ def get_repeaters_uuids(obj: dict[str, dict[str, list]]) -> Iterable[uuid.UUID]:
                     yield uuid.UUID(object["uuid"])
 
 
+def all_repeater_uuids(obj: dict[str, Any]) -> set[uuid.UUID]:
+    """
+    Every repeater-row ``uuid`` in ``obj``, at every nesting depth.
+
+    ``get_repeaters_uuids`` only looks one level deep. SeparatedSubmission rows
+    are keyed by these uuids (plus the root submission pk), and nested repeaters
+    produce their own rows, so any reconcile that deletes rows whose uuid is
+    absent from the canonical fields must see *all* depths — otherwise it would
+    wrongly delete legitimately-nested rows on forms with nested repeaters (#2252).
+    """
+    found: set[uuid.UUID] = set()
+    if not isinstance(obj, dict):
+        return found
+    for field in get_repeaters(obj):
+        for row in obj[field]:
+            if not isinstance(row, dict):
+                continue
+            raw = row.get("uuid")
+            if raw is not None:
+                found.add(raw if isinstance(raw, uuid.UUID) else uuid.UUID(str(raw)))
+            found |= all_repeater_uuids(row)
+    return found
+
+
 def flatten(
     obj: dict[str, Any],
     parent_key: list[str] | None = None,

--- a/formkit_ninja/management/commands/reconcile_separated_submissions.py
+++ b/formkit_ninja/management/commands/reconcile_separated_submissions.py
@@ -1,0 +1,61 @@
+"""One-time data repair for orphaned SeparatedSubmission rows (#2252).
+
+A repeater-row ``SeparatedSubmission`` (and its CASCADE-linked children and
+dependent Import/Flag rows) is orphaned whenever a row's ``uuid`` disappears from
+canonical ``Submission.fields`` without the on-save reconcile catching it —
+historically the case for bulk saves, flat<->repeater migrations, string->Decimal
+retypes, and imports that bypassed ``Submission.save``.
+
+The orphans are invisible in canonical fields but ARE served by the derived-model
+endpoints, so they double-count in cumulative aggregates. This command sweeps
+every Submission and deletes the orphans directly (no re-save, so it neither
+churns uuids nor re-fires the split). It is idempotent — a no-op once consistent —
+and is meant to run on deploy and on every fresh staging/prod restore. Going
+forward, the reconcile inside ``SeparatedSubmission.objects.from_submission``
+keeps new orphans from accumulating on every save.
+
+Submission is canonical — this only deletes derived rows with no counterpart in
+canonical fields; it never writes SeparatedSubmission models.
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from formkit_ninja.form_submission.models import SeparatedSubmission, Submission
+from formkit_ninja.form_submission.utils import all_repeater_uuids
+
+
+class Command(BaseCommand):
+    help = "Delete orphaned SeparatedSubmission rows whose uuid is absent from canonical Submission.fields (#2252)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would be deleted without persisting any changes.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run: bool = options["dry_run"]
+
+        scanned = 0
+        submissions_with_orphans = 0
+        orphan_rows = 0
+
+        for sub in Submission.objects.iterator(chunk_size=200):
+            scanned += 1
+            valid_uuids = {sub.pk} | all_repeater_uuids(sub.fields or {})
+            orphans = SeparatedSubmission.objects.filter(submission_id=sub.pk).exclude(pk__in=valid_uuids)
+            count = orphans.count()
+            if not count:
+                continue
+            submissions_with_orphans += 1
+            orphan_rows += count
+            self.stdout.write(self.style.WARNING(f"Submission {sub.pk}: {count} orphaned SeparatedSubmission row(s)" + (" (dry-run)" if dry_run else "")))
+            if not dry_run:
+                # CASCADE removes child rows and their dependent Import/Flag rows.
+                orphans.delete()
+
+        summary = f"Scanned {scanned} submission(s); {submissions_with_orphans} with orphans; {orphan_rows} orphan row(s) " + ("would be deleted (dry-run)." if dry_run else "deleted.")
+        self.stdout.write(self.style.SUCCESS(summary))

--- a/formkit_ninja/management/commands/reconcile_separated_submissions.py
+++ b/formkit_ninja/management/commands/reconcile_separated_submissions.py
@@ -35,27 +35,73 @@ class Command(BaseCommand):
             action="store_true",
             help="Report what would be deleted without persisting any changes.",
         )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help=(
+                "Proceed even when a submission's canonical fields declare NO repeaters "
+                "but derived repeater rows exist (the blast-radius guard). Without this, "
+                "such submissions are skipped and reported — they are usually a blanked / "
+                "oddly-shaped Submission.fields rather than a genuine full removal."
+            ),
+        )
 
     def handle(self, *args, **options):
         dry_run: bool = options["dry_run"]
+        force: bool = options["force"]
 
         scanned = 0
         submissions_with_orphans = 0
         orphan_rows = 0
+        reparented_rows = 0
+        guarded = 0
+        failed = 0
 
         for sub in Submission.objects.iterator(chunk_size=200):
             scanned += 1
-            valid_uuids = {sub.pk} | all_repeater_uuids(sub.fields or {})
+
+            # One malformed document must not abort the whole sweep.
+            try:
+                repeater_uuids = all_repeater_uuids(sub.fields or {})
+            except (ValueError, TypeError) as exc:
+                failed += 1
+                self.stderr.write(self.style.ERROR(f"Submission {sub.pk}: could not parse fields ({exc}); skipping"))
+                continue
+
+            valid_uuids = {sub.pk} | repeater_uuids
             orphans = SeparatedSubmission.objects.filter(submission_id=sub.pk).exclude(pk__in=valid_uuids)
             count = orphans.count()
             if not count:
                 continue
+
+            # Blast-radius guard: canonical fields declare zero repeaters yet derived
+            # repeater rows exist. This is the catastrophic case — a blanked or
+            # oddly-shaped Submission.fields would otherwise delete every derived row.
+            # It is also how a genuine "all repeaters removed" save looks, so we skip
+            # and report rather than delete, and let an operator opt in with --force.
+            if not repeater_uuids and not force:
+                guarded += 1
+                self.stdout.write(self.style.WARNING(f"Submission {sub.pk}: {count} orphan(s) but fields declare no repeaters — skipped (use --force to delete)"))
+                continue
+
             submissions_with_orphans += 1
             orphan_rows += count
             self.stdout.write(self.style.WARNING(f"Submission {sub.pk}: {count} orphaned SeparatedSubmission row(s)" + (" (dry-run)" if dry_run else "")))
             if not dry_run:
-                # CASCADE removes child rows and their dependent Import/Flag rows.
+                # Cascade-safe: a valid (kept) row can still point its repeater_parent
+                # at an orphan whose uuid changed via an ungoverned mutation. Detach
+                # those first so the orphan delete's CASCADE does not take a live row;
+                # the next real save re-derives the correct parent via from_submission.
+                reparented = SeparatedSubmission.objects.filter(submission_id=sub.pk, repeater_parent__in=orphans, pk__in=valid_uuids).update(repeater_parent=None)
+                reparented_rows += reparented
+                # CASCADE removes orphan child rows and their dependent Import/Flag rows.
                 orphans.delete()
 
         summary = f"Scanned {scanned} submission(s); {submissions_with_orphans} with orphans; {orphan_rows} orphan row(s) " + ("would be deleted (dry-run)." if dry_run else "deleted.")
+        if reparented_rows:
+            summary += f" Re-pointed {reparented_rows} live row(s) off orphan parents."
+        if guarded:
+            summary += f" {guarded} submission(s) skipped by blast-radius guard (use --force)."
+        if failed:
+            summary += f" {failed} submission(s) skipped due to unparseable fields."
         self.stdout.write(self.style.SUCCESS(summary))

--- a/tests/form_submission/test_reconcile_command.py
+++ b/tests/form_submission/test_reconcile_command.py
@@ -75,3 +75,66 @@ def test_repair_command_dry_run_deletes_nothing():
     # Dry run reports but persists nothing.
     assert SeparatedSubmission.objects.filter(pk=orphan_uuid).exists()
     assert SeparatedSubmission.objects.filter(pk=live_uuid).exists()
+
+
+@pytest.mark.django_db
+def test_blast_radius_guard_skips_when_fields_declare_no_repeaters():
+    """A submission whose canonical fields declare no repeaters but still has
+    derived repeater rows is skipped by default (guards against blanked fields),
+    and only deleted with --force."""
+    sub = Submission.objects.create(fields={"repeater": [{"uuid": str(uuid.uuid4()), "amount": 1}]}, form_type="TestForm")
+    rep_uuid = SeparatedSubmission.objects.get(submission=sub, repeater_key="repeater").pk
+
+    # Blank the repeaters out of canonical fields WITHOUT signals — simulates a
+    # bad migration / odd-shaped fields leaving derived rows behind.
+    Submission.objects.filter(pk=sub.pk).update(fields={})
+
+    # Default: guard skips, row survives.
+    call_command("reconcile_separated_submissions")
+    assert SeparatedSubmission.objects.filter(pk=rep_uuid).exists()
+
+    # --force: now it is deleted.
+    call_command("reconcile_separated_submissions", "--force")
+    assert not SeparatedSubmission.objects.filter(pk=rep_uuid).exists()
+
+
+@pytest.mark.django_db
+def test_cascade_safe_keeps_valid_child_under_orphan_parent():
+    """A valid (kept) row whose repeater_parent points at an orphan must NOT be
+    cascade-deleted when the orphan is removed; it is detached instead."""
+    parent_old = uuid.uuid4()
+    child = uuid.uuid4()
+    sub = Submission.objects.create(
+        fields={"level1": [{"uuid": str(parent_old), "name": "p", "level2": [{"uuid": str(child), "name": "c"}]}]},
+        form_type="NestedForm",
+    )
+    assert SeparatedSubmission.objects.filter(pk=child).exists()
+
+    # Parent uuid churns to a new value via an ungoverned update (no signal), but
+    # the child row in the DB still points repeater_parent -> old parent.
+    parent_new = uuid.uuid4()
+    Submission.objects.filter(pk=sub.pk).update(fields={"level1": [{"uuid": str(parent_new), "name": "p", "level2": [{"uuid": str(child), "name": "c"}]}]})
+
+    call_command("reconcile_separated_submissions")
+
+    # Old parent (orphan) is gone; the valid child survives, detached.
+    assert not SeparatedSubmission.objects.filter(pk=parent_old).exists()
+    assert SeparatedSubmission.objects.filter(pk=child).exists()
+    assert SeparatedSubmission.objects.get(pk=child).repeater_parent_id is None
+
+
+@pytest.mark.django_db
+def test_unparseable_fields_do_not_abort_sweep():
+    """A submission with a malformed repeater uuid is skipped without aborting the
+    run, so later submissions still get reconciled."""
+    bad = Submission.objects.create(fields={"x": 1}, form_type="TestForm")
+    # Plant a non-uuid string in a repeater position so all_repeater_uuids raises.
+    Submission.objects.filter(pk=bad.pk).update(fields={"repeater": [{"uuid": "not-a-uuid", "amount": 1}]})
+
+    _sub, orphan_uuid, live_uuid = _make_orphan()
+
+    # Should not raise; the good submission is still reconciled.
+    call_command("reconcile_separated_submissions")
+
+    assert not SeparatedSubmission.objects.filter(pk=orphan_uuid).exists()
+    assert SeparatedSubmission.objects.filter(pk=live_uuid).exists()

--- a/tests/form_submission/test_reconcile_command.py
+++ b/tests/form_submission/test_reconcile_command.py
@@ -1,0 +1,77 @@
+"""
+Tests for the ``reconcile_separated_submissions`` management command (#2252).
+
+The command sweeps pre-existing orphaned SeparatedSubmission rows — derived rows
+whose uuid no longer appears in the canonical Submission.fields. These accumulated
+historically from bulk/ungoverned saves the on-save reconcile never governed.
+"""
+
+import uuid
+
+import pytest
+from django.core.management import call_command
+
+from formkit_ninja.form_submission.models import SeparatedSubmission, Submission
+
+
+def _make_orphan() -> tuple[Submission, uuid.UUID, uuid.UUID]:
+    """Create a submission with one live row, then plant a pre-existing orphan.
+
+    The on-save reconcile now self-heals, so a fresh ``from_submission`` can no
+    longer leave an orphan behind — exactly the point of the fix. To reproduce a
+    *historical* orphan (one created before the reconcile shipped), insert a stray
+    SeparatedSubmission row directly: a derived row whose uuid is absent from the
+    canonical ``Submission.fields``.
+    """
+    live_uuid = uuid.uuid4()
+    sub = Submission.objects.create(
+        fields={"repeater": [{"uuid": str(live_uuid), "amount": 100}]},
+        form_type="TestForm",
+    )
+    main = SeparatedSubmission.objects.get(pk=sub.pk)
+    assert SeparatedSubmission.objects.filter(pk=live_uuid).exists()
+
+    orphan_uuid = uuid.uuid4()
+    SeparatedSubmission.objects.create(
+        pk=orphan_uuid,
+        submission=sub,
+        user=sub.user,
+        status=sub.status,
+        fields={"amount": 100},
+        form_type="TestFormRepeater",
+        repeater_key="repeater",
+        repeater_parent=main,
+        repeater_order=1,
+    )
+
+    # Both rows now exist: the live one and the planted orphan.
+    assert SeparatedSubmission.objects.filter(pk=live_uuid).exists()
+    assert SeparatedSubmission.objects.filter(pk=orphan_uuid).exists()
+    return sub, orphan_uuid, live_uuid
+
+
+@pytest.mark.django_db
+def test_repair_command_removes_preexisting_orphan_and_is_idempotent():
+    _sub, orphan_uuid, live_uuid = _make_orphan()
+
+    call_command("reconcile_separated_submissions")
+
+    assert not SeparatedSubmission.objects.filter(pk=orphan_uuid).exists()
+    assert SeparatedSubmission.objects.filter(pk=live_uuid).exists()
+
+    # Idempotent: a second run leaves the consistent data untouched.
+    before = set(SeparatedSubmission.objects.values_list("pk", flat=True))
+    call_command("reconcile_separated_submissions")
+    after = set(SeparatedSubmission.objects.values_list("pk", flat=True))
+    assert before == after
+
+
+@pytest.mark.django_db
+def test_repair_command_dry_run_deletes_nothing():
+    _sub, orphan_uuid, live_uuid = _make_orphan()
+
+    call_command("reconcile_separated_submissions", "--dry-run")
+
+    # Dry run reports but persists nothing.
+    assert SeparatedSubmission.objects.filter(pk=orphan_uuid).exists()
+    assert SeparatedSubmission.objects.filter(pk=live_uuid).exists()

--- a/tests/test_submission_models.py
+++ b/tests/test_submission_models.py
@@ -65,6 +65,81 @@ class TestSubmissionLifecycle:
         assert child1
         assert child1.repeater_parent == level1
 
+    def test_changed_repeater_uuid_deletes_orphan(self):
+        """
+        #2252: when a repeater row's uuid changes on re-save, the old derived
+        SeparatedSubmission row must be reconciled away — not left orphaned.
+
+        Orphans are invisible in canonical Submission.fields but ARE served by
+        the derived-model endpoints, so a stale row double-counts in aggregates.
+        """
+        import uuid
+
+        old_uuid = uuid.uuid4()
+        sub = Submission.objects.create(
+            fields={"repeater": [{"uuid": str(old_uuid), "amount": 100}]},
+            form_type="TestForm",
+        )
+        assert SeparatedSubmission.objects.filter(pk=old_uuid).exists()
+
+        # Web-form round-trip / retype: same row, fresh uuid.
+        new_uuid = uuid.uuid4()
+        sub.fields = {"repeater": [{"uuid": str(new_uuid), "amount": 100}]}
+        sub.save()
+
+        assert SeparatedSubmission.objects.filter(pk=new_uuid).exists()
+        assert not SeparatedSubmission.objects.filter(pk=old_uuid).exists()
+        assert SeparatedSubmission.objects.filter(submission=sub, repeater_key="repeater").count() == 1
+
+    def test_removed_repeater_row_deletes_orphan(self):
+        """#2252: removing a repeater row on re-save deletes its derived row."""
+        import uuid
+
+        keep_uuid = uuid.uuid4()
+        drop_uuid = uuid.uuid4()
+        sub = Submission.objects.create(
+            fields={"repeater": [{"uuid": str(keep_uuid), "amount": 1}, {"uuid": str(drop_uuid), "amount": 2}]},
+            form_type="TestForm",
+        )
+        assert SeparatedSubmission.objects.filter(submission=sub, repeater_key="repeater").count() == 2
+
+        sub.fields = {"repeater": [{"uuid": str(keep_uuid), "amount": 1}]}
+        sub.save()
+
+        assert SeparatedSubmission.objects.filter(submission=sub, repeater_key="repeater").count() == 1
+        assert SeparatedSubmission.objects.filter(pk=keep_uuid).exists()
+        assert not SeparatedSubmission.objects.filter(pk=drop_uuid).exists()
+
+    def test_nested_repeater_rows_not_wrongly_deleted(self):
+        """
+        #2252: reconcile must not delete legitimately-nested rows at any depth.
+
+        Re-saving an unchanged nested structure must leave every derived row
+        (root + level1 + level2) intact.
+        """
+        import uuid
+
+        l2a, l2b = uuid.uuid4(), uuid.uuid4()
+        l1 = uuid.uuid4()
+        data = {
+            "level1": [
+                {
+                    "uuid": str(l1),
+                    "name": "parent1",
+                    "level2": [{"uuid": str(l2a), "name": "child1"}, {"uuid": str(l2b), "name": "child2"}],
+                }
+            ]
+        }
+        sub = Submission.objects.create(fields=data, form_type="NestedForm")
+
+        # Re-save the identical structure.
+        sub.fields = data
+        sub.save()
+
+        assert SeparatedSubmission.objects.filter(submission=sub).count() == 4  # root + l1 + 2x l2
+        for pk in (l1, l2a, l2b):
+            assert SeparatedSubmission.objects.filter(pk=pk).exists()
+
     def test_form_type_preserves_underscores_in_numeric_parts(self):
         """
         Verify that form_type generation preserves underscores before numeric parts.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,10 @@ def test_short_uuid_from_uuid():
     u = uuid4()
     result = short_uuid(u)
     assert len(result) == 8
-    assert result.isupper()
+    # `str.isupper()` is False when the string has no cased characters, so an
+    # all-digit hex prefix (~2% of random uuids) would flake. Check that the
+    # value is already uppercased instead — robust for digit-only prefixes.
+    assert result == result.upper()
     assert result == str(u).replace("-", "")[:8].upper()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ wheels = [
 
 [[package]]
 name = "formkit-ninja"
-version = "2.4"
+version = "2.5"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Why

Carries the protection from partisipa-import [PR #2259](https://github.com/catalpainternational/partisipa-import/pull/2259) **upstream into FormkitNinja, at its source**.

The root cause of that bug lives here, not in partisipa. `SeparatedSubmission.objects.from_submission` upserts one derived row per repeater-row `uuid` but **never deleted** rows whose `uuid` had disappeared from canonical `Submission.fields`. A row's uuid changes/disappears on a normal save when:

- the web-form round-trip drops/regenerates `uuid` (and `SubmissionField.pre_save` → `ensure_repeater_uuid` mints a fresh uuid for any row missing one),
- flat↔repeater migrations or string→Decimal retypes churn it,
- an import bypasses `Submission.save`.

The orphaned derived rows are invisible in canonical `fields` but **are** served by the derived-model (`/api/submissions/v2`) endpoints, so they double-count in cumulative aggregates — e.g. partisipa's FF 11 infrastructure carryforward read \$19,140.12 instead of \$19,178.55 (a single \$38.43 expenditure counted twice).

Partisipa worked around this in its own `signals.py` with a *stateful, diff-based* cleanup that was disabled for all bulk/post-migration saves, so orphans accumulated permanently. Putting the fix in `from_submission` instead means every FormkitNinja consumer gets it for free and partisipa's bespoke cleanup can be retired.

## What changed

- **`form_submission/models.py`** — `from_submission` now tracks the pks it writes (root + every repeater row at every nesting depth, since `flatten` already recurses) and deletes any other `SeparatedSubmission` for the submission, inside the existing atomic transaction. Stateless and self-healing; runs on every save. Using the just-written set (not a separate uuid walk) means it can never wrongly delete a legitimately-nested row.
- **`form_submission/utils.py`** — `all_repeater_uuids()`, a recursive collector at all depths, complementing the one-level `get_repeaters_uuids`.
- **`reconcile_separated_submissions` management command** (`--dry-run`) — idempotent sweep of pre-existing orphans across all submissions, for deploy / fresh staging-prod restore. Consumers (partisipa) call this from their own deploy hook, keeping the dbsamizdat-view timing concern in the deployment layer.
- **CHANGELOG** `[Unreleased]`.

## ⚠️ Behavioral change

A derived row absent from canonical fields is now deleted on save, cascading to its child rows and their dependent `SeparatedSubmissionImport` / `Flag` rows. This is intended — a row not in canonical data shouldn't retain import history or QA flags — but downstream code that assumed orphans lingered should be aware.

## Tests (TDD red→green)

- `tests/test_submission_models.py` — uuid-changes-on-resave deletes the orphan; removed-row deletes the orphan; **nested repeaters at all depths are NOT wrongly deleted**.
- `tests/form_submission/test_reconcile_command.py` — repair removes a planted pre-existing orphan, leaves the live row, is idempotent (second run deletes 0), and `--dry-run` persists nothing.
- Full suite green; ruff + mypy clean.