### PR TITLE
v2.5.1 chore: release 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.1] - 2026-06-18
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "formkit-ninja"
-version = "2.5"
+version = "2.5.1"
 description = "A Django-Ninja backend to specify FormKit schemas"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ wheels = [
 
 [[package]]
 name = "formkit-ninja"
-version = "2.5"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Why

The `2.5` release was tagged on 2026-06-16, **before** the orphaned-`SeparatedSubmission` reconcile fix ([#43](https://github.com/catalpainternational/formkit-ninja/pull/43)) merged to `main`. That fix is therefore on `main` but not in any published release, and `main`'s declared version (`2.5`) collided with the already-published `2.5`.

This cuts a patch release so the fix can ship to PyPI.

## What changed

- `pyproject.toml` + `uv.lock`: `2.5` → `2.5.1`
- `CHANGELOG.md`: `[Unreleased]` → `[2.5.1] - 2026-06-18`

No code changes.

## Release steps after merge

`release.yml` publishes to PyPI (OIDC Trusted Publishing) and creates the GitHub release on a version tag. After this merges:

```
git checkout main && git pull
git tag 2.5.1 && git push origin 2.5.1
```

(matching the existing `2.4` / `2.5` tag naming — no `v` prefix)